### PR TITLE
Don't overwrite the jdbcTemplate if already set

### DIFF
--- a/src/main/java/com/nurkiewicz/jdbcrepository/JdbcRepository.java
+++ b/src/main/java/com/nurkiewicz/jdbcrepository/JdbcRepository.java
@@ -86,7 +86,9 @@ public abstract class JdbcRepository<T extends Persistable<ID>, ID extends Seria
 
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		obtainJdbcTemplate();
+		if(jdbcOperations == null){
+			obtainJdbcTemplate();
+		}
 		if (sqlGenerator == null) {
 			obtainSqlGenerator();
 		}


### PR DESCRIPTION
Checking if the jdbcOperations/template has been set prior to getting the default from the beanFactory.

This is my fix at least.  Refs #20 